### PR TITLE
fix: add refreshTimeout on page load and successful token refresh

### DIFF
--- a/src/Index.vue
+++ b/src/Index.vue
@@ -126,9 +126,10 @@ export default {
     ...mapMutations('alerts', [
       'updateSidebarAlert',
     ]),
-    ...mapActions('membership', {
-      dropUser: 'dropUser',
-    }),
+    ...mapActions('membership', [
+      'dropUser',
+      'setRefreshTimeout',
+    ]),
     ...mapActions('localization', [
       'setLang',
     ]),
@@ -218,6 +219,7 @@ export default {
     this.hubSubscribe();
 
     if (this.isLoggedIn) {
+      this.setRefreshTimeout();
       this.getProfileData();
       this.getCurrencies();
     };

--- a/src/store/modules/membership.js
+++ b/src/store/modules/membership.js
@@ -11,6 +11,8 @@ export default {
     userId: '',
     email: '',
     lastAction: '',
+    tokenRefreshTime: 30000,
+    maxInactiveTime: 86400000,
   },
   getters: {
     isLoggedIn: (state) => {
@@ -37,11 +39,13 @@ export default {
     },
   },
   actions: {
+    regFinish({state, commit}, code) {
+      return Membership.regFinish(code).then((response) => {
+        commit('createUser', response.data);
+      });
+    },
     login({commit, dispatch}, {email, password}) {
-      return Membership.login({
-        email,
-        password,
-      }).then((response) => {
+      return Membership.login({email, password}).then((response) => {
         commit('createUser', response.data);
         dispatch('setRefreshTimeout');
       });
@@ -49,6 +53,32 @@ export default {
     logout({dispatch, state}) {
       return Membership.logout(state.refreshToken).then(() => {
         dispatch('dropUser');
+      });
+    },
+    dropUser({commit}) {
+      commit('flushUser');
+      commit('orders/cleanOrders', null, {root: true});
+      commit('user/cleanAfterLogout', null, {root: true});
+      commit('modal/open', {name: 'signIn'}, {root: true});
+    },
+    refreshToken({state, commit, dispatch}) {
+      return new Promise((resolve, reject) => {
+        let timeSinceLastAction = Date.now() - state.lastAction;
+        if (timeSinceLastAction > state.maxInactiveTime) {
+          return reject();
+        } else {
+          Membership.refreshToken({
+            grantType: 'RefreshToken',
+            refreshToken: state.refreshToken,
+            email: state.email,
+          }).then((response) => {
+            commit('createUser', response.data);
+            dispatch('setRefreshTimeout');
+            return resolve(response);
+          }).catch((response) => {
+            return reject(response);
+          });
+        };
       });
     },
     tryReconnect({getters, dispatch}) {
@@ -66,42 +96,10 @@ export default {
         };
       });
     },
-    dropUser({commit}) {
-      commit('flushUser');
-      commit('orders/cleanOrders', null, {root: true});
-      commit('user/cleanAfterLogout', null, {root: true});
-      commit('modal/open', {name: 'signIn'}, {root: true});
-    },
-    regFinish({state, commit}, code) {
-      return Membership.regFinish(code).then((response) => {
-        commit('createUser', response.data);
-      });
-    },
     setRefreshTimeout({state, commit, dispatch}) {
       setTimeout(() => {
-        dispatch('refreshToken').then(() => {
-          dispatch('setRefreshTimeout');
-        });
-      }, 1800000);
-    },
-    refreshToken({state, commit, dispatch}) {
-      return new Promise((resolve, reject) => {
-        let timeSinceLastAction = Date.now() - state.lastAction;
-        if (timeSinceLastAction > 86400000) {
-          return reject();
-        } else {
-          Membership.refreshToken({
-            grantType: 'RefreshToken',
-            refreshToken: state.refreshToken,
-            email: state.email,
-          }).then((response) => {
-            commit('createUser', response.data);
-            return resolve(response);
-          }).catch((response) => {
-            return reject(response);
-          });
-        };
-      });
+        dispatch('refreshToken');
+      }, state.tokenRefreshTime);
     },
     rememberLastAction({getters, commit}) {
       if (getters.isLoggedIn) commit('setLastActionTime');


### PR DESCRIPTION
The current reconnect functionality is intended for 2 scenarios:
1. Initial login and subsequent token refreshing before token expiration on the backend.
2. Page open and token refresh attempt if refresh token is available and an acceptable amount of time has passed after last action (currently 24 hours).

See store/memebrship.js (refresh behaviour), Index.vue (set refresh timeout on created hook), services/api/api.js (401 error interception).

Possible issues: 
1. Excessive Promise use.
2. Multiple requests resulting in 401 result in multiple refresh calls.
3. dropUser action calls other module mutations.
4. Confusing action structure in membership.js.